### PR TITLE
Fix the gem name

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,5 @@
-= Savage
+= Reevoo Savage Transform
+The original gem is on https://github.com/qhwa/savage, which we had to fork and publish it to our internal gems server. This gem was not published on Rubygems.org and was not possible to use it as a dependency in our scores_svg gem.
 
 A little gem for extracting and manipulating SVG vector path data, Savage will make your life easier when it comes time to dynamically draw new and manipulate existing SVG paths. No more wacky regex to capture those cryptic path data strings; just pass the whole "d" attribute into Savage's parser, et voilá: You'll be given an instance of Savage::Path, replete with an array of subpaths split on the "move to" commands (to better help with those pesky winding issues). In turn, each subpath contains its own array of directions that can be swapped around, reconfigured, and otherwise manipulated to your heart's content in a truly human-readable way.
 

--- a/reevoo_savage_transform.gemspec
+++ b/reevoo_savage_transform.gemspec
@@ -3,17 +3,14 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.homepage         = "http://github.com/qhwa/savage"
+  spec.homepage         = "https://github.com/reevoo/reevoo_savage_transform"
   spec.rubygems_version = "2.2.2"
   spec.summary          = "A little library to manipulate SVG path data. Path commands can be transformed."
-  spec.name             = "savage-transform"
+  spec.name             = "reevoo_savage_transform"
   spec.version          = "1.3.0"
   spec.authors          = ["qhwa", "Jeremy Holland"]
   spec.description      = "A little gem for extracting and manipulating SVG vector path data. Path commands can be transfromed."
   spec.email            = ["qhwa@163.com", "jeremy@jeremypholland.com"]
-  spec.summary          = %q{extract color information from images}
-  spec.description      = %q{extract color information from images}
-  spec.homepage         = "https://github.com/qhwa/color_extract"
   spec.license          = "MIT"
   spec.files            = `git ls-files`.split($/)
   spec.executables      = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
- after we forked the gem from original github repo, we needed to fix the name of the gem, to be able properly add this gem as a dependency of scores_svg library